### PR TITLE
Issue #6 - Migrate Japan blog content to site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,13 +58,13 @@ plugins:
   - jekyll-include-cache
 
 author:
-  name   : "Luis Cruz"
-  avatar : "/assets/images/bio-photo.jpg"
-  bio    : "My awesome biography constrained to a sentence or two goes here."
+  name: "Luis Cruz"
+  avatar: "/assets/images/bio-photo.jpg"
+  bio: "My awesome biography constrained to a sentence or two goes here."
   links:
-#    - label: "Website"
-#      icon: "fas fa-fw fa-link"
-#      url: "https://"
+    #    - label: "Website"
+    #      icon: "fas fa-fw fa-link"
+    #      url: "https://"
     - label: "Twitter"
       icon: "fab fa-fw fa-twitter-square"
       url: "https://twitter.com/sprak"
@@ -98,7 +98,7 @@ defaults:
       read_time: true
       comments: true
       share: true
-      related: true
+      related: false
   # _pages
   - scope:
       path: "_pages"
@@ -113,3 +113,10 @@ category_archive:
 tag_archive:
   type: liquid
   path: /tags/
+
+# Enable comments via staticman provider
+repository: sprak3000/sprak3000.github.io
+
+# Staticman comments (full configuration in staticman.yml)
+staticman:
+  branch: "master"

--- a/_data/comments/im-big-in-japan-akihabara/comment-1178416260.yml
+++ b/_data/comments/im-big-in-japan-akihabara/comment-1178416260.yml
@@ -1,0 +1,7 @@
+_id: d1bfb5a4-8784-40ec-b1f1-f367d3a1b18a
+_parent: /blog/2007/05/im-big-in-japan-akihabara/
+message: "<p>\"I have no illusions that Jm will be a huge anime fan, but she has moved on to enjoy similar titles like Rose of Versailles.\"</p>If she's into shoujo, I recommend Mars, Backstage Prince[Found it yet?], Aishiteruze Baby, Utena, Absolute Boyfriend, and Nana. Paradise Kiss is short, but it's a \"love it or hate it\" series. I hear Kodocha's fun, too."
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-05-05T21:51:44.455Z'

--- a/_data/comments/im-big-in-japan-akihabara/comment-1178460780.yml
+++ b/_data/comments/im-big-in-japan-akihabara/comment-1178460780.yml
@@ -1,0 +1,8 @@
+_id: bcb688dd-ee93-4489-af2e-439e97d826ca
+_parent: /blog/2007/05/im-big-in-japan-akihabara/
+replying_to: '1'
+message: "<p>@Daniel</p><p>Not sure if any of those would pique her interest; period pieces, especially ones focused on the Victorian era in Europe, go over better with her.</p><p>As for Backstage Prince, I have yet to find a b&m store around here that carries it or many (if any) Viz titles.</p>"
+name:  Luis Cruz
+url: ''
+hidden: ''
+date: '2007-05-06T10:13:44.455Z'

--- a/_data/comments/im-big-in-japan-akihabara/comment-1178508420.yml
+++ b/_data/comments/im-big-in-japan-akihabara/comment-1178508420.yml
@@ -1,0 +1,8 @@
+_id: 95096f54-2f9e-4cc7-9b75-da8111f64226
+_parent: /blog/2007/05/im-big-in-japan-akihabara/
+replying_to: '1'
+message: "That's a surprise. Guess you'll have to settle for Amazon, dude. As for period pieces, if CPM put Tale of the Genji on dvd, I'd recommend it."
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-05-06T23:27:44.455Z'

--- a/_data/comments/im-big-in-japan-arrival/comment-1168063620.yml
+++ b/_data/comments/im-big-in-japan-arrival/comment-1168063620.yml
@@ -1,0 +1,7 @@
+_id: fcd275e7-7292-45d6-882e-9a290c79c3a2
+_parent: /blog/2007/01/im-big-in-japan-the-arrival/
+message: "If you lost a few pounds, you'd be a dead ringer for Steve Carell."
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-01-06T01:07:44.455Z'

--- a/_data/comments/im-big-in-japan-arrival/comment-1168100700.yml
+++ b/_data/comments/im-big-in-japan-arrival/comment-1168100700.yml
@@ -1,0 +1,8 @@
+_id: b9739a56-5a8d-49b3-9109-aee830de3302
+_parent: /blog/2007/01/im-big-in-japan-the-arrival/
+replying_to: '1'
+message: "<p>@Daniel</p>I don't see it, but OK. It will be interesting to see if that opinion holds when I post some better pictures near the end of the trip."
+name:  Luis Cruz
+url: ''
+hidden: ''
+date: '2007-01-06T11:25:44.455Z'

--- a/_data/comments/im-big-in-japan-asakusa/comment-1169388480.yml
+++ b/_data/comments/im-big-in-japan-asakusa/comment-1169388480.yml
@@ -1,0 +1,7 @@
+_id: 99f2da88-77ca-4222-a1de-1c9663c5ed98
+_parent: /blog/2007/01/im-big-in-japan-asakusa-ginza/
+message: "<p>\"I briefly toyed with getting a PSP but resisted the urge.\"</p><p>I'm guessing they're like $500 over there too, huh?</p><p>\"Our hotel was located right next to Shinjuku station\"</p><p>That explains why it was cheap. Run into any yakuza? ^_-</p>"
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-01-21T09:08:44.455Z'

--- a/_data/comments/im-big-in-japan-asakusa/comment-1169394360.yml
+++ b/_data/comments/im-big-in-japan-asakusa/comment-1169394360.yml
@@ -1,0 +1,8 @@
+_id: 57818da7-c9fe-4915-be03-e47ed3a8bae6
+_parent: /blog/2007/01/im-big-in-japan-asakusa-ginza/
+replying_to: '1'
+message: "<p>@Daniel</p><p>I don't recall how much they were at the time; it was only a few months since it was released. So, it was still pretty expensive. That's why I briefly toyed with picking one up. :)</p><p>As for the Keio, it wasn't cheap in any way; it is a very nice hotel. Shinjuku covers a large area; I'd have to check the map, but I believe we were in or close to the Nishi-Shinjuku area which houses a lot of skyscrapers. The area you are thinking of is Kabukicho where all the \"hostess\" bars, pachinko parlors, and such are.</p>"
+name:  Luis Cruz
+url: ''
+hidden: ''
+date: '2007-01-21T10:46:44.455Z'

--- a/_data/comments/im-big-in-japan-harajuku-and-shibuya/comment-1179985140.yml
+++ b/_data/comments/im-big-in-japan-harajuku-and-shibuya/comment-1179985140.yml
@@ -1,0 +1,7 @@
+_id: c8b99c91-0873-4aff-9cd9-37c8158db136
+_parent: /blog/2007/05/im-big-in-japan-harajuku-and-shibuya/
+message: "<p>'It is a bit surreal to watch anime now, see Hachikō Square, and be able to point and say \"I sat right there once!\"'</p><p>One of the characters in Nana is nick-named Hachi-after the dog.</p><p>\"He showed us that the best way to eat tempura is to place some grated daikon in the sauce.\"</p><p>I need to try that one. Anyway, just another reason for you to check out Nerima Daikon Bros. ^_-</p><p>\"eel,\"</p><p>Did it taste like chicken?</p>"
+name: Tequila
+url: ''
+hidden: ''
+date: '2007-05-24T01:39:44.455Z'

--- a/_data/comments/im-big-in-japan-harajuku-and-shibuya/comment-1179985200.yml
+++ b/_data/comments/im-big-in-japan-harajuku-and-shibuya/comment-1179985200.yml
@@ -1,0 +1,8 @@
+_id: 9e1f56cd-2849-4d71-9e36-fe61cf156761
+_parent: /blog/2007/05/im-big-in-japan-harajuku-and-shibuya/
+replying_to: '1'
+message: "Sorry, that last comment was by me. I use the nick elsewhere."
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-05-24T01:40:44.455Z'

--- a/_data/comments/im-big-in-japan-harajuku-and-shibuya/comment-1180006920.yml
+++ b/_data/comments/im-big-in-japan-harajuku-and-shibuya/comment-1180006920.yml
@@ -1,0 +1,8 @@
+_id: 118d6923-8356-460c-8151-848d922bea85
+_parent: /blog/2007/05/im-big-in-japan-harajuku-and-shibuya/
+replying_to: '1'
+message: "<p>@Tequila/Daniel</p>Properly prepared eel tastes nothing like chicken. Give it a try, if you haven't already. I've loved it since the first bite."
+name:  Luis Cruz
+url: ''
+hidden: ''
+date: '2007-05-24T07:42:44.455Z'

--- a/_data/comments/im-big-in-japan-kabuki/comment-1169937360.yml
+++ b/_data/comments/im-big-in-japan-kabuki/comment-1169937360.yml
@@ -1,0 +1,7 @@
+_id: 51429296-5ed6-4cf2-9434-17de2ff8eaff
+_parent: /blog/2007/01/im-big-in-japan-a-night-of-kabuki/
+message: "<p>\"We were off to experience the traditional theater experience of Kabuki and needed to be at the Hamamatsucho bus terminal by 5:30PM.\"</p><p>If you're really into kabuki, might I recommend the recent manga Backstage Prince from Viz? Oh, and here's the walk-through of Kabuki Quantum Fighter for kicks. http://www.youtube.com/watch?v=Q453p_Dwvag</p><p>\"Now, I'll let you in on the most important tip no one seems to tell you about riding the trains in Japan....The most important thing to determine before setting foot on a train is what exit you want to take once you arrive at the station.\"</p><p>I thought the most important thing is to watch out for gropers. Or is that only in anime and manga?</p>"
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-01-27T17:36:44.455Z'

--- a/_data/comments/im-big-in-japan-mt-fuji/comment-1171427760.yml
+++ b/_data/comments/im-big-in-japan-mt-fuji/comment-1171427760.yml
@@ -1,0 +1,7 @@
+_id: 0c7c491a-2c8a-4099-a111-188c0be65af3
+_parent: /blog/2007/02/im-big-in-japan-mt-fuji/
+message: "<p>\"Breakfast at Jurin was simple and light, juice and croissants, and set us back only(!) 3245¥.\"</p>That's about 34 bucks, if I'm not mistaken? Just go to 7-11 or McDees, dude.<p>\"Blessed with sunny but windy weather, I quickly setup the tripod and began snapping panoramic shots of Fuji-san and the other visible mountain ranges, dubbed the Japanese Alps.\"</p>Did you meet Heidi? ^_- Anyway, very nice scenery. You should post some of this stuff in the Japanese Language and Culture section at AOD."
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-02-13T23:36:44.455Z'

--- a/_data/comments/im-big-in-japan-mt-fuji/comment-1171467000.yml
+++ b/_data/comments/im-big-in-japan-mt-fuji/comment-1171467000.yml
@@ -1,0 +1,8 @@
+_id: e8b86c3a-a1c2-439f-bc7f-517489e12c7b
+_parent: /blog/2007/02/im-big-in-japan-mt-fuji/
+replying_to: '1'
+message: "<p>@Daniel</p>You don't realize how much you are spending at the time. I didn't realize it until I sat down and started writing out this journal. Once we hit Kyoto, we were having breakfast for significantly less money thanks to a bakery near our hotel."
+name:  Luis Cruz
+url: ''
+hidden: ''
+date: '2007-02-14T10:30:44.455Z'

--- a/_data/comments/im-big-in-japan-preparation/comment-1167803460.yml
+++ b/_data/comments/im-big-in-japan-preparation/comment-1167803460.yml
@@ -1,0 +1,7 @@
+_id: 7430365c-13c8-4e8a-b0b6-05caecfaa75c
+_parent: /blog/2007/01/im-big-in-japan-preparation/
+message: "<p>\"Grand total for the adventure, including airfare, came to just under $6500.\"</p>Damn. I don't think I could afford that anytime soon. And that doesn't include the souvenirs, does it? Thanks for the shoe info. I might consider it in the future. Know any good stores to buy pants?"
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-01-03T12:51:44.455Z'

--- a/_data/comments/im-big-in-japan-preparation/comment-1167828720.yml
+++ b/_data/comments/im-big-in-japan-preparation/comment-1167828720.yml
@@ -1,0 +1,8 @@
+_id: 0336c4a6-a8ad-4d2e-a895-f7813dd30182
+_parent: /blog/2007/01/im-big-in-japan-preparation/
+replying_to: '1'
+message: "<p>@DZ</p>Yeah, it's not something I could do every year, but we're pretty good about managing our money and saving it up over time. As for pants, I just find whatever fits and looks good for the cheapest price. I've been shopping at <a href=\"http://www.kohls.com/\">Kohls</a> lately; they have a decent selection, but I don't think they are a national chain."
+name:  Luis Cruz
+url: ''
+hidden: ''
+date: '2007-01-03T12:51:44.455Z'

--- a/_data/comments/im-big-in-japan-prologue/comment-1167726120.yml
+++ b/_data/comments/im-big-in-japan-prologue/comment-1167726120.yml
@@ -1,0 +1,7 @@
+_id: fcefdef0-bfa0-11e6-8f5c-bda410f1d942
+_parent: /blog/2007/01/im-big-in-japan-prologue/
+message: "You could always skim through \"Cruising the Anime City\" by Patrick Macias to help refresh your memory."
+name:  Daniel Zelter
+url: ''
+hidden: ''
+date: '2007-01-02T03:22:44.455Z'

--- a/_data/comments/im-big-in-japan-prologue/comment-1167743640.yml
+++ b/_data/comments/im-big-in-japan-prologue/comment-1167743640.yml
@@ -1,0 +1,8 @@
+_id: 6888acc0-bfcc-11e6-8f5c-bda410f1d942
+_parent: /blog/2007/01/im-big-in-japan-prologue/
+replying_to: '1'
+message: "<p>@DZ</p>I could, but he wasn't on the trip with me. So, no help there. :)"
+name: Luis Cruz
+url: ''
+hidden: ''
+date: '2007-01-02T08:14:33.341Z'

--- a/_includes/comment-form.html
+++ b/_includes/comment-form.html
@@ -1,0 +1,44 @@
+{% unless page.comments_locked == true %}
+<!-- Start comment form -->
+<div id="respond" class="comment__form">
+    <h2 class="title">Leave a comment <small><a rel="nofollow" id="cancel-comment-reply-link" href="{{ page.url | relative_url }}#respond" style="display:none;">Cancel reply</a></small></h2>
+    <form id="comment-form" class="js-form" method="post" action="https://api.staticman.net/v3/entry/github/{{ site.repository }}/{{ site.staticman.branch }}/comments">
+        <div class="form__group">
+            <label for="comment-form-name">Name
+                <input type="text" id="comment-form-name" name="fields[name]" required spellcheck="false" placeholder="Your name">
+            </label>
+            <label for="comment-form-email">E-mail
+                <input type="email" id="comment-form-email" name="fields[email]" required spellcheck="false" placeholder="email@domain.com">
+            </label>
+            <label for="comment-form-url">Website (optional)
+                <input type="url" id="comment-form-url" name="fields[url]" placeholder="https://domain.com">
+            </label>
+        </div>
+        <div class="form__group">
+            <label for="comment-form-message">Comment
+                <textarea rows="6" id="comment-form-message" name="fields[message]" required spellcheck="true" placeholder="Your message"></textarea>
+            </label>
+        </div>
+        <input type="hidden" name="options[origin]" value="{{ page.url | relative_url }}">
+        <input type="hidden" name="options[parent]" value="{{ page.url | relative_url }}">
+        <input type="hidden" id="comment-replying-to" name="fields[replying_to]" value="">
+        <input type="hidden" id="comment-post-id" name="options[slug]" value="{{ page.slug }}">
+        <input type="hidden" name="options[reCaptcha][siteKey]" value="{{ site.reCaptcha.siteKey }}">
+        <input type="hidden" name="options[reCaptcha][secret]" value="{{ site.reCaptcha.secret }}">
+        <!-- Start comment form alert messaging -->
+        <div class="hidden js-notice notice">
+            <p class="js-notice-text"></p>
+        </div>
+        <!-- End comment form alert messaging -->
+        <div class="g-recaptcha form__group" data-sitekey="{{ site.reCaptcha.siteKey }}"></div>
+        <button type="submit" id="comment-form-submit">Send comment</button>
+    </form>
+</div>
+<!-- End comment form -->
+<script async src="https://www.google.com/recaptcha/api.js"></script>
+{% else %}
+<div class="notice">
+    <h4>Comments are closed</h4>
+    <p>If you have a question concerning the content of this page, please feel free to <a href="/contact/">contact me</a>.</p>
+</div>
+{% endunless %}

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -1,0 +1,55 @@
+<div id="comment{% unless include.r %}{{ index | prepend: '-' }}{% else %}{{ include.index | prepend: '-' }}{% endunless %}" class="js-comment comment {% unless include.replying_to == 0 %}child{% endunless %}">
+    {% if site.comment-avatar %}
+    <div class="comment__avatar">
+        {% if include.avatar %}
+        <noscript><img src="{{ include.avatar }}" alt=""></noscript>
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="{{ include.avatar }}" alt="" class="lazyload blur-up">
+        {% elsif include.email %}
+        <noscript><img src="https://www.gravatar.com/avatar/{{ include.email }}?d=mm&s=60" alt=""></noscript>
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-srcset="https://www.gravatar.com/avatar/{{ include.email }}?d=mm&s=60 1x, https://www.gravatar.com/avatar/{{ include.email }}?d=mm&s=120 2x" alt="" class="lazyload blur-up">
+        {% else %}
+        <noscript><img src="/assets/images/avatar-60.png" alt=""></noscript>
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-srcset="https://www.gravatar.com/avatar/{{ include.email }}?d=mm&s=60 1x, /assets/images/avatar-120.png 2x" alt="" class="lazyload blur-up">
+        {% endif %}
+    </div>
+    {% endif %}
+    <div class="comment__main">
+        <div class="comment__meta">
+            {% unless include.url == blank %}
+            <a rel="external nofollow" href="{{ include.url }}"><strong class="h-card">{{ include.name | strip_html }}</strong></a>
+            {% else %}
+            <strong class="h-card">{{ include.name | strip_html }}</strong>
+            {% endunless %}
+            {% if include.date %}
+            on
+            {% if include.index %}<a href="#comment{% if r %}{{ index | prepend: '-' }}{% else %}{{ include.index | prepend: '-' }}{% endif %}" title="Permalink to this comment">{% endif %}
+            <time datetime="{{ include.date | date_to_xmlschema }}">{{ include.date | date_to_long_string: 'ordinal', 'US' }}</time>
+            {% if include.index %}</a>{% endif %}
+            {% endif %}
+        </div>
+        <div class="comment__message">
+            {{ include.message | markdownify }}
+        </div>
+        {% if site.comment-form %}}
+        {% unless include.replying_to != 0 or page.comments_locked == true %}
+        <div class="comment__reply">
+            <a rel="nofollow" href="#comment-{{ include.index }}" onclick="return addComment.moveForm('comment-{{ include.index }}', '{{ include.index }}', 'respond', '{{ page.slug }}')"><svg class="icon icon--reply" width="16px" height="16px"><use xlink:href="{{ 'icons.svg#icon-reply' | prepend: 'assets/icons/' | relative_url }}"></use></svg> Reply to {{ include.name }}</a>
+        </div>
+        {% endunless %}
+        {% endif %}
+    </div>
+</div>
+
+{% capture i %}{{ include.index }}{% endcapture %}
+{% assign replies = site.data.comments[page.slug] | sort | where_exp: 'comment', 'comment[1].replying_to == i' %}
+{% for reply in replies %}
+{% assign index       = forloop.index | prepend: '-' | prepend: include.index %}
+{% assign replying_to = reply[1].replying_to | to_integer %}
+{% assign avatar      = reply[1].avatar %}
+{% assign email       = reply[1].email %}
+{% assign name        = reply[1].name %}
+{% assign url         = reply[1].url %}
+{% assign date        = reply[1].date %}
+{% assign message     = reply[1].message %}
+{% include comment.html index=index replying_to=replying_to avatar=avatar email=email name=name url=url date=date message=message %}
+{% endfor %}

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,0 +1,29 @@
+{% if site.repository and site.staticman.branch %}
+{% if site.data.comments[page.slug] %}
+<section id="comments" class="page__comments js-comments">
+    <h2 class="title">
+        {% if site.data.comments[page.slug].size <= 1 %}
+        {{ site.data.comments[page.slug] | size | append: ' comment' }}
+        {% elsif site.data.comments[page.slug].size > 1 %}
+        {{ site.data.comments[page.slug] | size | append: ' comments' }}
+        {% endif %}
+    </h2>
+    {% assign comments = site.data.comments[page.slug] | sort | where_exp: 'comment', 'comment[1].replying_to == blank' %}
+    {% for comment in comments %}
+    {% assign index       = forloop.index %}
+    {% assign replying_to = comment[1].replying_to | to_integer %}
+    {% assign avatar      = comment[1].avatar %}
+    {% assign email       = comment[1].email %}
+    {% assign name        = comment[1].name %}
+    {% assign url         = comment[1].url %}
+    {% assign date        = comment[1].date %}
+    {% assign message     = comment[1].message %}
+    {% include comment.html index=index replying_to=replying_to avatar=avatar email=email name=name url=url date=date message=message %}
+    {% endfor %}
+</section>
+{% endif %}
+
+{% if site.comment-form %}
+{% include comment-form.html %}
+{% endif %}
+{% endif %}

--- a/staticman.yml
+++ b/staticman.yml
@@ -1,0 +1,16 @@
+comments:
+  allowedFields: ["name", "url", "message", "replying_to"]
+  branch: "master"
+  commitMessage: "New comment."
+  filename: "comment-{@timestamp}"
+  format: "yaml"
+  moderation: true
+  path: "src/_data/comments/{options.slug}"
+  requiredFields: ["name", "message"]
+  transforms:
+    email: md5
+  generatedFields:
+    date:
+      type: "date"
+      options:
+        format: "iso8601"


### PR DESCRIPTION
* Add staticman configuration and templates to power comments. Used https://mademistakes.com/articles/improving-jekyll-static-comments/ as base for building. Had to look at the source for that blog in GitHub to find the latest ways the author was using.
* Add comments for the Japan blog posts.