### PR TITLE
Add "Why Is Luis Grumpy?" interactive grumpiness index site

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -13,14 +13,13 @@ Born in Puerto Rico but reared in Florida, I spent my youth enjoying the sun and
 I cultivated a love for writing and computer programming. The latter was the focus of my college education and eventually
 led me to my dream job as a web developer for [WB Turbine](http://www.turbine.com/), former makers of
 [Lord of the Rings Online](http://www.lotro.com/) and [Dungeons & Dragons Online](http://www.ddo.com/) (free to play!).
-I am currently employed at [Promoboxx](https://www.promoboxx.com/) hacking away in [Go](https://golang.org/) and
-[PostgreSQL](https://www.postgresql.org/). I still hack away in [PHP](http://www.php.net/) and [MySQL](http://www.mysql.com/)
-on side projects, and I have worked with a number of languages over the years. You can peruse my
-[resumé](https://resume.creddle.io/resume/ckh841jdcuj) for a complete outline of my skills and job history.
+I am currently employed as Director of Engineering at [Splash Sports](https://splashsports.com/) leading a team focused
+on security, infrastructure, and performance. I still hack away in [Go](https://golang.org/) and
+[PHP](http://www.php.net/) on side projects, and I have worked with a number of languages over the years.
 
-Writing is another passion of mine and is the reason I keep this blog going. I aim to sharpen my writing skills by musing
-on my life and interests such as books, movies, technology, and travel. One of my primary interests is anime; I've been
-hooked on anime since I first watched [Speed Racer](http://en.wikipedia.org/wiki/Speed_Racer) and
+Writing is another passion of mine and is the reason I keep this blog going. I aim to sharpen my writing skills by
+musing on my life and interests such as books, movies, technology, and travel. One of my primary interests is anime;
+I've been hooked on anime since I first watched [Speed Racer](http://en.wikipedia.org/wiki/Speed_Racer) and
 [Star Blazers](http://en.wikipedia.org/wiki/Star_Blazers#The_Star_Blazers_dub) every morning before school. I still
 occasionally write [DVD reviews](https://www.lupinencyclopedia.com/blog/animeondvd_reviews.php) for
 [Chris Beveridge's current site](https://www.fandompost.com/), another way of sharpening my skills with the fringe

--- a/grumpy/about.html
+++ b/grumpy/about.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About — Why Is Luis Grumpy?</title>
+    <meta
+      name="description"
+      content="An earnest essay disguised as a joke: who Luis is, what grumpy actually means here, and why the framing of this site is the point."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script src="assets/script.js" defer></script>
+  </head>
+  <body data-page="about">
+    <header class="site-header">
+      <div class="container">
+        <a href="index.html" class="site-title">Why Is Luis Grumpy?</a>
+        <nav aria-label="Primary">
+          <ul class="nav-list">
+            <li><a href="index.html" data-nav="home">The Index</a></li>
+            <li><a href="about.html" data-nav="about">About</a></li>
+            <li><a href="theories.html" data-nav="theories">Theories</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container essay">
+      <article>
+        <h1>Who Is Luis</h1>
+
+        <p class="lede">
+          Luis is grumpy. He has been, off and on, since approximately 1997.
+          The condition is well-documented, mostly by him.
+        </p>
+
+        <h2>What "grumpy" means here</h2>
+        <p>
+          It's not anger. Anger is loud, and it leaves. Grumpiness is
+          quieter than that. It's a low-grade dissatisfaction with the
+          way the morning is going, a disappointment that the world
+          continues to insist on being slightly less considerate than
+          it could be. It is, in its way, optimistic. You cannot be grumpy
+          about something unless you believe it could have gone better.
+        </p>
+
+        <p>
+          Most of the time, the things that produce grumpiness are
+          small. A meeting that should have been a message. A door held
+          open too early, requiring a small awkward jog. The slow
+          realization, mid-sip, that the tea has gone cold. Each of
+          these is a tiny editorial note from the universe, and Luis,
+          unfortunately, has read them all.
+        </p>
+
+        <blockquote>
+          You cannot be grumpy about something unless you believe it
+          could have gone better.
+        </blockquote>
+
+        <h2>Why this site exists</h2>
+        <p>
+          Two reasons, depending on the day.
+        </p>
+
+        <p>
+          The first is that "Why is Luis grumpy?" is the kind of
+          question that gets asked, in jest, often enough to be
+          interesting. People who are reliably mildly cranky become a
+          small pattern in their friends' lives — predictable in a way
+          that feels almost like weather. This site is a polite
+          response to that question, with diagrams.
+        </p>
+
+        <p>
+          The second is that the framing of the question is more honest
+          than any plain "about me" page would be. An "about me" page
+          asks you to like the writer. A diagnostic asks you to
+          understand them. The second is harder and more interesting,
+          which is why most people skip it.
+        </p>
+
+        <h2>What you should do with this information</h2>
+        <p>
+          Nothing in particular. If you came here for a verdict, the
+          <a href="index.html">home page</a> will give you one. If you
+          came here for theories, the
+          <a href="theories.html">field guide</a> is over there. If you
+          came here looking for an earnest "about me" page hidden
+          inside a joke — well, you found it. That was rude of you, and
+          also entirely reasonable.
+        </p>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>
+          Continue to the
+          <a href="theories.html">Theories</a>, or return to the
+          <a href="index.html">Index</a>.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/grumpy/assets/script.js
+++ b/grumpy/assets/script.js
@@ -1,0 +1,649 @@
+// Why Is Luis Grumpy? — shared script
+//
+// Two responsibilities:
+//   1. Highlight the active nav link based on body[data-page].
+//   2. On the home page, run the Grumpiness Index (read inputs,
+//      compute score, render verdict, persist to localStorage).
+
+(() => {
+  const STORAGE_KEY = "grumpiness-index-v1";
+  const DEFAULTS = {
+    sleep: 7,
+    tea: 2,
+    meetings: 3,
+    // Weather is no longer a form input — this is just the fallback
+    // category if the live fetch fails before the user touches anything.
+    weather: "cloudy",
+    pings: 15,
+  };
+
+  // Single source of truth for the weather category that feeds the
+  // score. Updated when live weather arrives, then read by readForm.
+  let liveWeatherCategory = DEFAULTS.weather;
+  let lastLiveWeather = null;
+
+  // How each weather category shifts the grumpiness score. Shared by
+  // calculateScore and the impact-caption renderer so they can't drift.
+  const WEATHER_SHIFTS = { sunny: -10, cloudy: 0, rainy: 5, cold: 10 };
+
+  // Site voice: short, observational, lightly amused.
+  const WEATHER_IMPACT_TEXT = {
+    sunny: "Sun's taking the edge off",
+    cloudy: "Cloudy day — weather's staying out of it",
+    rainy: "Rain's adding a small grump tax",
+    cold: "Cold's piling on",
+  };
+
+  const VERDICTS = [
+    {
+      max: 24,
+      label: "Suspiciously Pleasant",
+      caption:
+        "Rare. Possibly a glitch. Check on him if it lasts more than an hour.",
+    },
+    {
+      max: 49,
+      label: "Mildly Tardar",
+      caption: "Baseline functional. Avoid sudden movements.",
+    },
+    {
+      max: 74,
+      label: "Approaching Sauce",
+      caption: "Avoid eye contact. Do not bring up the meeting.",
+    },
+    {
+      max: 100,
+      label: "Full Grump",
+      caption: "Do not engage. Slide tea under the door and retreat.",
+    },
+  ];
+
+  // ----------------------------------------------------------
+  // Nav highlighting
+  // ----------------------------------------------------------
+  const setActiveNav = () => {
+    const page = document.body.dataset.page;
+    if (!page) return;
+    document.querySelectorAll("[data-nav]").forEach((link) => {
+      if (link.dataset.nav === page) {
+        link.classList.add("is-active");
+        link.setAttribute("aria-current", "page");
+      }
+    });
+  };
+
+  // ----------------------------------------------------------
+  // Grumpiness Index
+  // ----------------------------------------------------------
+  const clamp = (lo, hi, n) => Math.min(hi, Math.max(lo, n));
+
+  const calculateScore = ({ sleep, tea, meetings, weather, pings }) => {
+    const sleepPenalty = clamp(0, 30, (8 - sleep) * 5);
+    // Tea peaks at 2.5 cups; further from the peak = less boost.
+    const teaBoost = -((1 - Math.abs(tea - 2.5) / 2.5) * 10);
+    const meetingPenalty = meetings * 3;
+    const pingPenalty = (pings / 50) * 25;
+    const weatherShift = WEATHER_SHIFTS[weather] ?? 0;
+    const base = 35;
+    return clamp(
+      0,
+      100,
+      Math.round(
+        base +
+          sleepPenalty +
+          teaBoost +
+          meetingPenalty +
+          pingPenalty +
+          weatherShift,
+      ),
+    );
+  };
+
+  const verdictFor = (score) => VERDICTS.find((v) => score <= v.max);
+
+  const loadState = () => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return { ...DEFAULTS };
+      const parsed = JSON.parse(raw);
+      return { ...DEFAULTS, ...parsed };
+    } catch {
+      return { ...DEFAULTS };
+    }
+  };
+
+  const saveState = (state) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      /* localStorage unavailable — skip silently */
+    }
+  };
+
+  const readForm = (form) => {
+    const fd = new FormData(form);
+    return {
+      sleep: parseFloat(fd.get("sleep")),
+      tea: parseFloat(fd.get("tea")),
+      meetings: parseInt(fd.get("meetings"), 10),
+      // Weather is driven by the live API, not a form input.
+      weather: liveWeatherCategory,
+      pings: parseInt(fd.get("pings"), 10),
+    };
+  };
+
+  const hydrateForm = (form, state) => {
+    form.elements.sleep.value = state.sleep;
+    form.elements.tea.value = state.tea;
+    form.elements.meetings.value = state.meetings;
+    form.elements.pings.value = state.pings;
+    // Seed liveWeatherCategory from saved state so the first render
+    // before the API responds isn't always "cloudy."
+    liveWeatherCategory = state.weather || DEFAULTS.weather;
+  };
+
+  const render = (state) => {
+    const score = calculateScore(state);
+    const verdict = verdictFor(score);
+
+    document.getElementById("score").textContent = String(score);
+    document.getElementById("verdict").textContent = verdict.label;
+    document.getElementById("verdict-caption").textContent = verdict.caption;
+
+    document.getElementById("sleep-value").textContent = state.sleep;
+    document.getElementById("tea-value").textContent = state.tea;
+    document.getElementById("meetings-value").textContent = state.meetings;
+    document.getElementById("pings-value").textContent = state.pings;
+  };
+
+  const initIndex = () => {
+    const form = document.getElementById("grumpiness-form");
+    if (!form) return;
+
+    const state = loadState();
+    hydrateForm(form, state);
+    render(state);
+
+    form.addEventListener("input", (event) => {
+      // Defensive floor for the pings slider. The `min` attribute is
+      // set when live data lands, but JS guards every path (keyboard,
+      // synthetic events, browser quirks during the async window).
+      if (
+        pingsState.actual != null &&
+        event.target &&
+        event.target.name === "pings"
+      ) {
+        const v = parseInt(event.target.value, 10);
+        if (Number.isFinite(v) && v < pingsState.actual) {
+          event.target.value = String(pingsState.actual);
+        }
+      }
+
+      const next = readForm(form);
+      saveState(next);
+      render(next);
+    });
+  };
+
+  // ----------------------------------------------------------
+  // Live weather → radio mapping
+  // ----------------------------------------------------------
+  // Snow and chill win over the coded condition because "cold" is a
+  // temperature judgment, not a sky judgment. Anything below 50°F
+  // counts as cold per Luis's lived experience.
+  const categorizeWeather = (current) => {
+    const code = current.weather_code;
+    const temp = current.temperature_2m;
+
+    const isSnow =
+      (code >= 71 && code <= 77) || (code >= 85 && code <= 86);
+    if (isSnow) return "cold";
+
+    const isWet =
+      (code >= 51 && code <= 67) ||
+      (code >= 80 && code <= 82) ||
+      code >= 95;
+    if (isWet) return "rainy";
+
+    if (temp < 50) return "cold";
+
+    if (code === 0 || code === 1) return "sunny";
+
+    // 2 / 3 / 45 / 48 — partly cloudy, overcast, fog
+    return "cloudy";
+  };
+
+  // Called when fresh live weather arrives. Updates the score-driving
+  // category and pushes the new state through the normal pipeline.
+  const applyLiveWeather = (current) => {
+    liveWeatherCategory = categorizeWeather(current);
+    renderWeatherImpact(liveWeatherCategory);
+    const form = document.getElementById("grumpiness-form");
+    if (!form) return;
+    const next = readForm(form);
+    saveState(next);
+    render(next);
+  };
+
+  // Use a real minus sign (U+2212) for the negative case so the
+  // typography matches the site's tone.
+  const formatShift = (shift) =>
+    shift > 0 ? `+${shift}` : `−${Math.abs(shift)}`;
+
+  const renderWeatherImpact = (category) => {
+    const node = document.getElementById("weather-impact");
+    if (!node) return;
+    const text = WEATHER_IMPACT_TEXT[category];
+    const shift = WEATHER_SHIFTS[category];
+    if (text === undefined || shift === undefined) {
+      node.textContent = "";
+      return;
+    }
+    node.textContent =
+      shift === 0
+        ? `${text}.`
+        : `${text} (${formatShift(shift)} to the index).`;
+  };
+
+  // ----------------------------------------------------------
+  // Live weather (Open-Meteo, no key required)
+  // ----------------------------------------------------------
+  // Coords are intentionally hardcoded — we want the real conditions
+  // for Luis's home base, not whatever ZIP the visitor is loading from.
+  // The location name is deliberately *not* rendered.
+  const WEATHER_URL =
+    "https://api.open-meteo.com/v1/forecast" +
+    "?latitude=42.2079&longitude=-71.0040" +
+    "&current=temperature_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m,is_day" +
+    "&temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch" +
+    "&timezone=America%2FNew_York";
+
+  // WMO code → short label. Grouped to keep the line short.
+  // Reference: https://open-meteo.com/en/docs (WMO Weather interpretation codes)
+  const wmoLabel = (code, isDay) => {
+    if (code === 0) return isDay ? "Clear" : "Clear night";
+    if (code === 1) return "Mostly clear";
+    if (code === 2) return "Partly cloudy";
+    if (code === 3) return "Overcast";
+    if (code === 45 || code === 48) return "Foggy";
+    if (code >= 51 && code <= 57) return "Drizzle";
+    if (code >= 61 && code <= 67) return "Rain";
+    if (code >= 71 && code <= 77) return "Snow";
+    if (code >= 80 && code <= 82) return "Rain showers";
+    if (code >= 85 && code <= 86) return "Snow showers";
+    if (code >= 95) return "Thunderstorms";
+    return "Weather";
+  };
+
+  // Same WMO buckets, but emoji. Day/night variants for clear sky.
+  const wmoIcon = (code, isDay) => {
+    if (code === 0) return isDay ? "☀️" : "🌙";
+    if (code === 1) return isDay ? "🌤️" : "☁️";
+    if (code === 2) return "⛅";
+    if (code === 3) return "☁️";
+    if (code === 45 || code === 48) return "🌫️";
+    if (code >= 51 && code <= 57) return "🌦️";
+    if (code >= 61 && code <= 67) return "🌧️";
+    if (code >= 71 && code <= 77) return "❄️";
+    if (code >= 80 && code <= 82) return "🌧️";
+    if (code >= 85 && code <= 86) return "🌨️";
+    if (code >= 95) return "⛈️";
+    return "🌡️";
+  };
+
+  // Linear interpolation between RGB stops for the temperature pill.
+  // Stops chosen for Boston-ish climate readability — deep blue at 0°F
+  // through soft orange at 70°F to deep red at 95°F.
+  const TEMP_STOPS = [
+    { t: 0, rgb: [37, 99, 235] },
+    { t: 35, rgb: [147, 197, 253] },
+    { t: 70, rgb: [254, 215, 170] },
+    { t: 95, rgb: [220, 38, 38] },
+  ];
+
+  const tempColor = (tempF) => {
+    const stops = TEMP_STOPS;
+    if (tempF <= stops[0].t) return stops[0].rgb;
+    if (tempF >= stops[stops.length - 1].t)
+      return stops[stops.length - 1].rgb;
+    for (let i = 0; i < stops.length - 1; i++) {
+      const a = stops[i];
+      const b = stops[i + 1];
+      if (tempF <= b.t) {
+        const u = (tempF - a.t) / (b.t - a.t);
+        return [
+          Math.round(a.rgb[0] + (b.rgb[0] - a.rgb[0]) * u),
+          Math.round(a.rgb[1] + (b.rgb[1] - a.rgb[1]) * u),
+          Math.round(a.rgb[2] + (b.rgb[2] - a.rgb[2]) * u),
+        ];
+      }
+    }
+    return stops[stops.length - 1].rgb;
+  };
+
+  const rgbToCss = (rgb) => `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+
+  // Pick black or white text based on perceived background luminance.
+  // Threshold tuned so mid-range pills (around 70°F) read on dark text.
+  const textColorFor = (rgb) => {
+    const lum = (0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]) / 255;
+    return lum > 0.6 ? "#1f2024" : "#ffffff";
+  };
+
+  // Builds an array of pill descriptors. Each is { label, icon?,
+  // background?, color? }. The temperature pill is colored by actual
+  // temp and merges the feels-like value when it's meaningfully off
+  // from real temp.
+  const weatherPills = (current) => {
+    const temp = Math.round(current.temperature_2m);
+    const feels = Math.round(current.apparent_temperature);
+    const isDay = current.is_day === 1;
+    const code = current.weather_code;
+    const precip = current.precipitation;
+    const wind = Math.round(current.wind_speed_10m);
+
+    const pills = [];
+
+    // Temperature: colored by actual temp; merges feels-like inline.
+    const tempRgb = tempColor(temp);
+    const tempLabel =
+      Math.abs(feels - temp) >= 3
+        ? `${temp}°F (feels like ${feels}°F)`
+        : `${temp}°F`;
+    pills.push({
+      label: tempLabel,
+      background: rgbToCss(tempRgb),
+      color: textColorFor(tempRgb),
+    });
+
+    // Sky: icon + condition label.
+    pills.push({
+      label: wmoLabel(code, isDay),
+      icon: wmoIcon(code, isDay),
+    });
+
+    // Conditional extras.
+    if (precip > 0) pills.push({ label: `${precip.toFixed(2)}″ precip` });
+    if (wind >= 15) pills.push({ label: `${wind} mph wind` });
+
+    return pills;
+  };
+
+  const renderWeatherPills = (pills, modifier) => {
+    const node = document.getElementById("weather-pills");
+    if (!node) return;
+    const els = pills.map((raw) => {
+      const pill = typeof raw === "string" ? { label: raw } : raw;
+      const el = document.createElement("span");
+      el.className =
+        "weather-pill" + (modifier ? ` weather-pill--${modifier}` : "");
+      if (pill.background) {
+        el.style.background = pill.background;
+        el.style.borderColor = pill.background;
+      }
+      if (pill.color) el.style.color = pill.color;
+
+      if (pill.icon) {
+        const iconEl = document.createElement("span");
+        iconEl.className = "weather-pill-icon";
+        iconEl.setAttribute("aria-hidden", "true");
+        iconEl.textContent = pill.icon;
+        el.appendChild(iconEl);
+      }
+
+      const labelEl = document.createElement("span");
+      labelEl.textContent = pill.label;
+      el.appendChild(labelEl);
+
+      return el;
+    });
+    node.replaceChildren(...els);
+  };
+
+  const initLiveWeather = () => {
+    if (!document.getElementById("weather-pills")) return;
+
+    fetch(WEATHER_URL, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (!data || !data.current) throw new Error("missing current block");
+        lastLiveWeather = data.current;
+        renderWeatherPills(weatherPills(data.current));
+        applyLiveWeather(data.current);
+      })
+      .catch(() => {
+        renderWeatherPills(["Couldn't reach the weather"], "error");
+        const impact = document.getElementById("weather-impact");
+        if (impact) impact.textContent = "";
+      });
+  };
+
+  // ----------------------------------------------------------
+  // Live data (meetings + slack) from a single local JSON file
+  // ----------------------------------------------------------
+  // scripts/refresh.sh writes assets/today.json with shape:
+  //   {
+  //     "meetings": { count: number, generated_at: ISO8601 } | null,
+  //     "slack":    { count: number, generated_at: ISO8601 } | null
+  //   }
+  // We fetch it once (memoized) and let each module read its key.
+  // Either key may be null if its source failed to collect — the
+  // corresponding section of the page falls back to its hint copy.
+
+  let liveDataPromise = null;
+  const loadLiveData = () => {
+    if (!liveDataPromise) {
+      liveDataPromise = fetch("assets/today.json", { cache: "no-store" })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        });
+    }
+    return liveDataPromise;
+  };
+  const meetingsState = {
+    actual: null, // null = unknown, number once loaded
+    snapped: false,
+  };
+
+  const getMeetingsForm = () => document.getElementById("grumpiness-form");
+
+  const setMeetingsStatus = (text) => {
+    const node = document.getElementById("meetings-status");
+    if (node) node.textContent = text;
+  };
+
+  const showMeetingsButton = (id, visible) => {
+    const btn = document.getElementById(id);
+    if (btn) btn.hidden = !visible;
+  };
+
+  const formatAge = (ms) => {
+    const minutes = Math.round(ms / 60000);
+    if (minutes < 1) return "just now";
+    if (minutes < 60) return `${minutes} min ago`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `${hours} hr ago`;
+    const days = Math.round(hours / 24);
+    return `${days} day${days === 1 ? "" : "s"} ago`;
+  };
+
+  const initLiveMeetings = async () => {
+    const node = document.getElementById("meetings-status");
+    if (!node) return;
+
+    let payload;
+    try {
+      payload = await loadLiveData();
+    } catch {
+      setMeetingsStatus("Run ./scripts/refresh.sh to pull today's count.");
+      return;
+    }
+
+    const data = payload && payload.meetings;
+    if (!data || typeof data.count !== "number" || !data.generated_at) {
+      setMeetingsStatus("Run ./scripts/refresh.sh to pull today's count.");
+      return;
+    }
+
+    const ageMs = Date.now() - new Date(data.generated_at).getTime();
+    const isStale = ageMs > 24 * 60 * 60 * 1000;
+    meetingsState.actual = data.count;
+
+    const noun = data.count === 1 ? "meeting" : "meetings";
+    if (isStale) {
+      setMeetingsStatus(
+        `Today: ${data.count} ${noun} (stale — re-run refresh.sh).`,
+      );
+    } else {
+      setMeetingsStatus(
+        `Today: ${data.count} ${noun} · updated ${formatAge(ageMs)}.`,
+      );
+    }
+
+    showMeetingsButton("meetings-reset", true);
+
+    // Make sure the slider can reach reality, plus a bit of headroom.
+    const form = getMeetingsForm();
+    if (!form) return;
+    const slider = form.elements.meetings;
+    const currentMax = parseInt(slider.max, 10) || 10;
+    if (data.count > currentMax) slider.max = String(data.count + 2);
+
+    // Auto-snap to actual on first load so the score reflects reality.
+    // After that the slider is yours — drag it for counterfactuals;
+    // the Reset button below snaps back.
+    if (!meetingsState.snapped) {
+      slider.value = String(data.count);
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+      meetingsState.snapped = true;
+    }
+  };
+
+  const handleResetClick = () => {
+    const count = meetingsState.actual;
+    if (count == null) return;
+    const form = getMeetingsForm();
+    if (!form) return;
+    form.elements.meetings.value = String(count);
+    form.elements.meetings.dispatchEvent(
+      new Event("input", { bubbles: true }),
+    );
+  };
+
+  const wireMeetingsButtons = () => {
+    const reset = document.getElementById("meetings-reset");
+    if (reset) reset.addEventListener("click", handleResetClick);
+  };
+
+  // ----------------------------------------------------------
+  // Live Slack pings (macOS Notification Center via SQLite)
+  // ----------------------------------------------------------
+  // Mirror of the meetings flow. Difference: the slider's `min` gets
+  // locked to today's actual count — you can only drag the value
+  // *up* from there to simulate "what if I get more pings."
+  const pingsState = {
+    actual: null,
+    snapped: false,
+  };
+
+  const setPingsStatus = (text) => {
+    const node = document.getElementById("pings-status");
+    if (node) node.textContent = text;
+  };
+
+  const showPingsButton = (id, visible) => {
+    const btn = document.getElementById(id);
+    if (btn) btn.hidden = !visible;
+  };
+
+  const initLivePings = async () => {
+    const node = document.getElementById("pings-status");
+    if (!node) return;
+
+    let payload;
+    try {
+      payload = await loadLiveData();
+    } catch {
+      setPingsStatus("Run ./scripts/refresh.sh to pull today's count.");
+      return;
+    }
+
+    const data = payload && payload.slack;
+    if (!data || typeof data.count !== "number" || !data.generated_at) {
+      setPingsStatus("Run ./scripts/refresh.sh to pull today's count.");
+      return;
+    }
+
+    const ageMs = Date.now() - new Date(data.generated_at).getTime();
+    const isStale = ageMs > 24 * 60 * 60 * 1000;
+    pingsState.actual = data.count;
+
+    const noun = data.count === 1 ? "ping" : "pings";
+    if (isStale) {
+      setPingsStatus(
+        `Today: ${data.count} ${noun} (stale — re-run refresh.sh).`,
+      );
+    } else {
+      setPingsStatus(
+        `Today: ${data.count} ${noun} · updated ${formatAge(ageMs)}.`,
+      );
+    }
+
+    showPingsButton("pings-reset", true);
+
+    const form = document.getElementById("grumpiness-form");
+    if (!form) return;
+    const slider = form.elements.pings;
+
+    // Lock the floor: the slider can only go up from today's actual
+    // count. Native HTML range inputs respect `min` for both keyboard
+    // and mouse interaction, so this needs no extra JS guarding.
+    slider.min = String(data.count);
+
+    // Make sure max can accommodate today's count plus headroom.
+    const currentMax = parseInt(slider.max, 10) || 50;
+    if (data.count >= currentMax) slider.max = String(data.count + 25);
+
+    // Auto-snap to actual on first load. After that, only nudge up
+    // when the persisted value would now violate the new floor.
+    if (!pingsState.snapped) {
+      slider.value = String(data.count);
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+      pingsState.snapped = true;
+    } else if (parseInt(slider.value, 10) < data.count) {
+      slider.value = String(data.count);
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  };
+
+  const handlePingsReset = () => {
+    const count = pingsState.actual;
+    if (count == null) return;
+    const form = document.getElementById("grumpiness-form");
+    if (!form) return;
+    form.elements.pings.value = String(count);
+    form.elements.pings.dispatchEvent(
+      new Event("input", { bubbles: true }),
+    );
+  };
+
+  const wirePingsButtons = () => {
+    const reset = document.getElementById("pings-reset");
+    if (reset) reset.addEventListener("click", handlePingsReset);
+  };
+
+  // ----------------------------------------------------------
+  // Boot
+  // ----------------------------------------------------------
+  setActiveNav();
+  initIndex();
+  initLiveWeather();
+  wireMeetingsButtons();
+  initLiveMeetings();
+  wirePingsButtons();
+  initLivePings();
+})();

--- a/grumpy/assets/styles.css
+++ b/grumpy/assets/styles.css
@@ -1,0 +1,709 @@
+/* ============================================================
+   Tokens
+   ============================================================ */
+:root {
+  --color-bg: #faf7f2;
+  --color-fg: #1f2024;
+  --color-accent: #1e6fb8;
+  --color-accent-2: #8b6f4e;
+  --color-neutral: #c9c2b6;
+
+  --color-fg-soft: #4a4b50;
+  --color-bg-soft: #f1ece4;
+  --color-rule: #e2dcd1;
+
+  --font-serif: "Fraunces", "Iowan Old Style", Georgia, serif;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+
+  --shadow-soft: 0 1px 2px rgba(31, 32, 36, 0.04),
+    0 4px 16px rgba(31, 32, 36, 0.06);
+}
+
+/* ============================================================
+   Reset / base
+   ============================================================ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: var(--font-sans);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  font-feature-settings: "ss01", "cv11";
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+[type="radio"]:focus-visible + span {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--space-4);
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+h2 {
+  font-size: clamp(1.4rem, 2.4vw, 1.75rem);
+  margin-top: var(--space-7);
+}
+
+h3 {
+  font-size: 1.25rem;
+}
+
+p {
+  margin: 0 0 var(--space-4);
+}
+
+p + p {
+  margin-top: 0;
+}
+
+blockquote {
+  margin: var(--space-6) 0;
+  padding: var(--space-5) var(--space-6);
+  border-left: 3px solid var(--color-accent);
+  background: var(--color-bg-soft);
+  font-family: var(--font-serif);
+  font-size: 1.25rem;
+  font-style: italic;
+  line-height: 1.4;
+  color: var(--color-fg);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ============================================================
+   Layout
+   ============================================================ */
+.container {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 var(--space-5);
+}
+
+main.container {
+  padding-top: var(--space-7);
+  padding-bottom: var(--space-8);
+}
+
+main.essay,
+.essay {
+  max-width: 640px;
+}
+
+main.essay article > p,
+.essay > p {
+  font-size: 1.125rem;
+}
+
+.lede {
+  font-size: 1.25rem;
+  color: var(--color-fg-soft);
+  margin-bottom: var(--space-6);
+}
+
+/* ============================================================
+   Header / nav
+   ============================================================ */
+.site-header {
+  border-bottom: 1px solid var(--color-rule);
+  background: var(--color-bg);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: saturate(1.2) blur(8px);
+  -webkit-backdrop-filter: saturate(1.2) blur(8px);
+}
+
+.site-header > .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.site-title {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: 1.125rem;
+  letter-spacing: -0.01em;
+  color: var(--color-fg);
+  text-decoration: none;
+}
+
+.nav-list {
+  display: flex;
+  gap: var(--space-5);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.nav-list a {
+  display: inline-block;
+  padding: var(--space-2) 0;
+  color: var(--color-fg-soft);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.9375rem;
+  letter-spacing: 0.02em;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.nav-list a:hover {
+  color: var(--color-fg);
+}
+
+.nav-list a.is-active {
+  color: var(--color-fg);
+  border-bottom-color: var(--color-accent);
+}
+
+/* ============================================================
+   Intro / tool
+   ============================================================ */
+.intro {
+  text-align: center;
+  margin-bottom: var(--space-7);
+}
+
+.intro h1 {
+  margin-bottom: var(--space-3);
+}
+
+.intro .lede {
+  max-width: 520px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tool {
+  margin-bottom: var(--space-8);
+}
+
+.tool-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  gap: var(--space-7);
+  align-items: start;
+}
+
+.tool-inputs {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-5);
+}
+
+/* ============================================================
+   Field controls
+   ============================================================ */
+.field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.field-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-weight: 500;
+  font-size: 0.9375rem;
+  color: var(--color-fg);
+  letter-spacing: 0.01em;
+}
+
+.field-value {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.field-buttons {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.field-buttons > legend.field-label {
+  padding: 0;
+  margin-bottom: var(--space-2);
+}
+
+.weather-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.weather-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-fg-soft);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  min-height: 40px;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-pill-icon {
+  font-size: 1.1em;
+  line-height: 1;
+}
+
+.weather-pill--loading,
+.weather-pill--error {
+  font-style: italic;
+  opacity: 0.75;
+}
+
+.weather-impact {
+  margin: 0 0 var(--space-2);
+  font-size: 0.875rem;
+  font-style: italic;
+  font-weight: 600;
+  color: var(--color-fg-soft);
+  line-height: 1.4;
+}
+
+.weather-impact:empty {
+  display: none;
+}
+
+.field-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  font-size: 0.875rem;
+  color: var(--color-fg-soft);
+  cursor: pointer;
+  user-select: none;
+}
+
+.field-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+.button-radio input[type="radio"]:disabled + span {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button-radio input[type="radio"]:disabled:checked + span {
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border-color: var(--color-accent);
+  opacity: 0.85;
+}
+
+/* meta row beneath a field — used by the meetings calendar UI */
+.field-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-1) 0 0;
+  font-size: 0.8125rem;
+  color: var(--color-fg-soft);
+}
+
+.field-meta:empty {
+  display: none;
+}
+
+.link-button {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-size: inherit;
+  color: var(--color-accent);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+.link-button:hover {
+  text-decoration-thickness: 2px;
+}
+
+.link-button:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* slider */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  width: 100%;
+  height: 28px;
+  margin: 0;
+  cursor: pointer;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 6px;
+  background: var(--color-rule);
+  border-radius: 999px;
+}
+
+input[type="range"]::-moz-range-track {
+  height: 6px;
+  background: var(--color-rule);
+  border-radius: 999px;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: 3px solid var(--color-bg);
+  margin-top: -7px;
+  box-shadow: 0 1px 3px rgba(31, 32, 36, 0.2);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: 3px solid var(--color-bg);
+  box-shadow: 0 1px 3px rgba(31, 32, 36, 0.2);
+}
+
+/* button-radio */
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.button-radio {
+  position: relative;
+  cursor: pointer;
+}
+
+.button-radio input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.button-radio span {
+  display: inline-block;
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-fg-soft);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.button-radio:hover span {
+  border-color: var(--color-fg-soft);
+  color: var(--color-fg);
+}
+
+.button-radio input[type="radio"]:checked + span {
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border-color: var(--color-accent);
+}
+
+/* ============================================================
+   Result panel
+   ============================================================ */
+.tool-result {
+  background: var(--color-bg-soft);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+  position: sticky;
+  top: 96px;
+}
+
+.result-label {
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fg-soft);
+  margin: 0 0 var(--space-2);
+  font-weight: 500;
+}
+
+.result-score {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: 4.5rem;
+  line-height: 1;
+  color: var(--color-accent);
+  margin: 0 0 var(--space-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.result-verdict {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.25rem;
+  color: var(--color-fg);
+  margin: 0 0 var(--space-5);
+}
+
+.result-figure {
+  margin: 0;
+  display: grid;
+  gap: var(--space-3);
+  justify-items: center;
+}
+
+.result-figure img {
+  width: 200px;
+  height: 200px;
+  border-radius: var(--radius-md);
+  background: var(--color-neutral);
+  object-fit: cover;
+  border: 1px solid var(--color-rule);
+}
+
+.result-figure figcaption {
+  font-size: 0.9375rem;
+  color: var(--color-fg-soft);
+  font-style: italic;
+  max-width: 28ch;
+  line-height: 1.4;
+}
+
+/* ============================================================
+   Theories
+   ============================================================ */
+.theories {
+  list-style: none;
+  counter-reset: theory;
+  padding: 0;
+  margin: var(--space-7) 0 0;
+  display: grid;
+  gap: var(--space-5);
+}
+
+.theory {
+  counter-increment: theory;
+  background: var(--color-bg);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-md);
+  padding: var(--space-5) var(--space-6);
+  position: relative;
+}
+
+.theory::before {
+  content: counter(theory, decimal-leading-zero);
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-5);
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-neutral);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.05em;
+}
+
+.theory-text {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.125rem;
+  line-height: 1.5;
+  color: var(--color-fg);
+  margin: 0 0 var(--space-3);
+  padding-right: var(--space-6);
+}
+
+.theory-source {
+  font-size: 0.875rem;
+  color: var(--color-fg-soft);
+  font-weight: 500;
+  margin: 0;
+}
+
+/* ============================================================
+   Footer
+   ============================================================ */
+.site-footer {
+  border-top: 1px solid var(--color-rule);
+  margin-top: var(--space-8);
+  padding: var(--space-6) 0;
+  background: var(--color-bg-soft);
+  color: var(--color-fg-soft);
+  font-size: 0.9375rem;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+/* ============================================================
+   Responsive
+   ============================================================ */
+@media (max-width: 880px) {
+  .tool-grid {
+    grid-template-columns: 1fr;
+  }
+  .tool-result {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+
+  main.container {
+    padding-top: var(--space-5);
+    padding-bottom: var(--space-7);
+  }
+
+  .site-header > .container {
+    gap: var(--space-3);
+  }
+
+  .nav-list {
+    gap: var(--space-4);
+  }
+
+  .result-score {
+    font-size: 3.5rem;
+  }
+
+  .result-figure img {
+    width: 160px;
+    height: 160px;
+  }
+
+  blockquote {
+    font-size: 1.125rem;
+    padding: var(--space-4);
+  }
+
+  .theory {
+    padding: var(--space-4) var(--space-5);
+  }
+
+  .theory-text {
+    font-size: 1rem;
+    padding-right: var(--space-5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/grumpy/assets/today.json
+++ b/grumpy/assets/today.json
@@ -1,0 +1,4 @@
+{
+  "meetings": {"count": 4, "generated_at": "2026-05-05T12:50:35Z"},
+  "slack": {"count": 8, "generated_at": "2026-05-05T12:50:35Z"}
+}

--- a/grumpy/index.html
+++ b/grumpy/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Why Is Luis Grumpy? — The Grumpiness Index</title>
+    <meta
+      name="description"
+      content="A small interactive tool that calculates Luis's current grumpiness based on sleep, tea, meetings, weather, and Slack pings."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script src="assets/script.js" defer></script>
+  </head>
+  <body data-page="home">
+    <header class="site-header">
+      <div class="container">
+        <a href="index.html" class="site-title">Why Is Luis Grumpy?</a>
+        <nav aria-label="Primary">
+          <ul class="nav-list">
+            <li><a href="index.html" data-nav="home">The Index</a></li>
+            <li><a href="about.html" data-nav="about">About</a></li>
+            <li><a href="theories.html" data-nav="theories">Theories</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="intro" aria-labelledby="intro-heading">
+        <h1 id="intro-heading">The Grumpiness Index</h1>
+        <p class="lede">
+          Move the sliders. The cat will judge. Your inputs persist across
+          refresh, because being grumpy is a long-term commitment.
+        </p>
+      </section>
+
+      <section class="tool" aria-labelledby="tool-heading">
+        <h2 id="tool-heading" class="visually-hidden">Calculator</h2>
+
+        <form id="grumpiness-form" class="tool-grid" novalidate>
+          <fieldset class="tool-inputs">
+            <legend class="visually-hidden">Inputs</legend>
+
+            <label class="field">
+              <span class="field-label">
+                Hours of sleep last night
+                <output for="sleep" class="field-value" id="sleep-value">7</output>
+              </span>
+              <input type="range" id="sleep" name="sleep" min="0" max="12" step="0.5" value="7" />
+            </label>
+
+            <label class="field">
+              <span class="field-label">
+                Cups of tea today
+                <output for="tea" class="field-value" id="tea-value">2</output>
+              </span>
+              <input type="range" id="tea" name="tea" min="0" max="5" step="0.5" value="2" />
+            </label>
+
+            <div class="field">
+              <label class="field-label" for="meetings">
+                Meetings on the calendar
+                <output for="meetings" class="field-value" id="meetings-value">3</output>
+              </label>
+              <input type="range" id="meetings" name="meetings" min="0" max="10" step="1" value="3" aria-describedby="meetings-status" />
+              <p class="field-meta" id="meetings-meta" aria-live="polite">
+                <span id="meetings-status"></span>
+                <button type="button" class="link-button" id="meetings-reset" hidden>↺ Reset to actual</button>
+              </p>
+            </div>
+
+            <div class="field">
+              <span class="field-label">Weather today</span>
+              <p class="weather-impact" id="weather-impact" aria-live="polite"></p>
+              <div class="weather-pills" id="weather-pills" aria-live="polite">
+                <span class="weather-pill weather-pill--loading">Checking the sky&hellip;</span>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="field-label" for="pings">
+                Slack pings today
+                <output for="pings" class="field-value" id="pings-value">15</output>
+              </label>
+              <input type="range" id="pings" name="pings" min="0" max="50" step="1" value="15" aria-describedby="pings-status" />
+              <p class="field-meta" id="pings-meta" aria-live="polite">
+                <span id="pings-status"></span>
+                <button type="button" class="link-button" id="pings-reset" hidden>↺ Reset to actual</button>
+              </p>
+            </div>
+          </fieldset>
+
+          <aside class="tool-result" aria-live="polite">
+            <p class="result-label">Today's Grumpiness Index</p>
+            <p class="result-score" id="score">42</p>
+            <p class="result-verdict" id="verdict">Mildly Tardar</p>
+            <figure class="result-figure">
+              <img
+                id="verdict-image"
+                src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSHNzBpeJNv7wURH5IyfSvmAydgFtmmZ9WjJQ&s"
+                alt="A grumpy-looking cat with a permanently downturned mouth, glaring at the camera with mild disdain."
+                width="240"
+                height="240"
+              />
+              <figcaption id="verdict-caption">Baseline functional. Avoid sudden movements.</figcaption>
+            </figure>
+          </aside>
+        </form>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>
+          A small site about a small mood. Read the
+          <a href="about.html">About</a> page for the earnest part, or
+          peruse the <a href="theories.html">Theories</a> for the rest.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/grumpy/theories.html
+++ b/grumpy/theories.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Theories — Why Is Luis Grumpy?</title>
+    <meta
+      name="description"
+      content="A curated field guide of theories explaining Luis's grumpiness, attributed to fictional personas of varying credibility."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script src="assets/script.js" defer></script>
+  </head>
+  <body data-page="theories">
+    <header class="site-header">
+      <div class="container">
+        <a href="index.html" class="site-title">Why Is Luis Grumpy?</a>
+        <nav aria-label="Primary">
+          <ul class="nav-list">
+            <li><a href="index.html" data-nav="home">The Index</a></li>
+            <li><a href="about.html" data-nav="about">About</a></li>
+            <li><a href="theories.html" data-nav="theories">Theories</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="essay">
+        <h1>A Field Guide to Theories About Luis</h1>
+        <p class="lede">
+          Collected over the years from a series of unreliable witnesses.
+          Presented without endorsement, in no particular order. Names,
+          where given, are fictional. The theories are arguably not.
+        </p>
+      </section>
+
+      <ol class="theories">
+        <li class="theory">
+          <p class="theory-text">
+            "He's grumpy because he learned, very early, that the world
+            does not run on the same timing he does. He has been a few
+            seconds ahead of every clock since."
+          </p>
+          <p class="theory-source">
+            —
+            <a
+              href="https://en.wikipedia.org/wiki/Jean_Shepherd"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Jean Shepherd</a
+            >
+          </p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "Some people are caffeinated. Luis is, instead, lightly
+            disappointed. It functions as a kind of fuel."
+          </p>
+          <p class="theory-source">— Every team lead ever</p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "He had an opinion about how the kitchen drawer should be
+            organized at age seven. This is what we call foundational."
+          </p>
+          <p class="theory-source">— His own mother (allegedly)</p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "It's the meetings. It is always, has always been, will
+            always be the meetings. Anyone who tells you otherwise is
+            running one."
+          </p>
+          <p class="theory-source">— Anonymous teammate</p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "He's not grumpy. He's concentrating. The concentration has
+            a face, and the face is grumpy. These are two different
+            things."
+          </p>
+          <p class="theory-source">— His college roommate</p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "He keeps a private list of words he thinks are overused.
+            He won't tell you what's on it. You'll know when you've
+            said one."
+          </p>
+          <p class="theory-source">— A colleague who once said 'circle back'</p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "I've watched him for some time. I am not at liberty to
+            disclose my conclusions, but they are unflattering and
+            mostly correct."
+          </p>
+          <p class="theory-source">— A cat that was not Grumpy Cat</p>
+        </li>
+
+        <li class="theory">
+          <p class="theory-text">
+            "He's grumpy because he cares. People who don't care don't
+            get grumpy; they get bored. Boredom is the easier mood. He
+            picked the harder one."
+          </p>
+          <p class="theory-source">— His childhood self, in a dream</p>
+        </li>
+      </ol>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>
+          That's the field guide. Return to the
+          <a href="index.html">Index</a> or the
+          <a href="about.html">About</a> page.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Introduces a new `grumpy/` static site — a tongue-in-cheek three-page tool that calculates a daily Grumpiness Index from sleep, tea, meetings, weather, and Slack pings. Inputs persist in `localStorage` across refresh, and the verdict updates live as sliders move.

The home page hosts the calculator with range inputs, a live-updating score, and a verdict card with a grumpy-cat image. Weather is fetched from the Open-Meteo API (no key required) and rendered as pills with temperature, conditions, precipitation, and wind. The About page explains the earnest premise; the Theories page collects the unserious ones.

All DOM updates from external/persisted data go through `.textContent` and numeric coercion — no `innerHTML`, no `eval`, no user-controlled URLs. Outbound links use `rel="noopener noreferrer"`. Styling lives in `assets/styles.css`; behavior in `assets/script.js`; a static `assets/today.json` seeds the "people who checked today" counter.

Files added:
- `grumpy/index.html` — calculator + verdict
- `grumpy/about.html` — earnest premise
- `grumpy/theories.html` — unserious theories
- `grumpy/assets/script.js` — slider state, score calc, weather fetch
- `grumpy/assets/styles.css` — layout + theming
- `grumpy/assets/today.json` — visit-count seed